### PR TITLE
feat: Add OpenAI GPT-5-nano translation engine (#47)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# OpenAI API 키 (https://platform.openai.com/api-keys에서 발급)
+OPENAI_API_KEY=sk-proj-your-api-key-here
+
+# DeepL API 키 (선택 사항)
+DEEPL_API_KEY=your-deepl-key-here
+
+# Gemini API 키 (선택 사항)
+GEMINI_API_KEY=your-gemini-key-here

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - **다양한 포맷 지원**: `PDF`, `DOCX`, `PPTX`, `HTML`, `Image` 포맷을 **인터랙티브 뷰어(HTML)** 형태로 변환 및 번역.
 - **문장 단위 병렬 번역**: 원문 한 문장, 번역문 한 문장을 정확히 매칭하여 가독성 극대화.
 - **레이아웃 보존**: 문서 내의 표(Table)와 이미지(Image)를 유지하며 번역.
-- **유연한 엔진 선택**: Google Translate(무료), DeepL(고품질), Gemini(문맥 이해) 지원.
+- **유연한 엔진 선택**: Google Translate(무료), DeepL(고품질), Gemini(문맥 이해), **OpenAI GPT-5-nano(최신 AI)** 지원.
 - **고성능 처리**: 멀티스레딩(`max_workers`)을 통한 대량 문서 고속 병렬 처리.
 
 ## 빠른 시작 (Quick Start)
@@ -47,7 +47,29 @@ python main.py sample.pdf
 
 # 옵션 사용 (DeepL 엔진, 일본어 번역)
 python main.py sample.pdf --engine deepl --to ja
+
+# OpenAI GPT-5-nano 사용
+python main.py sample.pdf --engine openai --to ko
 ```
+
+### API 키 설정 (선택 사항)
+
+DeepL, Gemini, OpenAI를 사용하려면 `.env` 파일에 API 키를 설정해야 합니다.
+
+```bash
+# .env.example을 .env로 복사
+cp .env.example .env
+
+# .env 파일 편집에 API 키 입력
+OPENAI_API_KEY=sk-proj-your-api-key-here
+DEEPL_API_KEY=your-deepl-key-here
+GEMINI_API_KEY=your-gemini-key-here
+```
+
+**API 키 발급 링크**:
+- [OpenAI API Keys](https://platform.openai.com/api-keys) - GPT-5-nano 사용 (입력 $0.05/1M, 출력 $0.40/1M 토큰)
+- [DeepL API](https://www.deepl.com/pro-api)
+- [Google AI Studio](https://aistudio.google.com/app/apikey) - Gemini 사용
 
 ### 3. Web UI 실행
 

--- a/app.py
+++ b/app.py
@@ -327,7 +327,7 @@ def main():
             )
             engine = st.selectbox(
                 t("engine_label"),
-                ["google", "deepl", "gemini"],
+                ["google", "deepl", "gemini", "openai"],
                 index=0,
             )
             max_workers = st.number_input(

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -22,7 +22,7 @@ Designed to overcome the **imperfections and context loss** often encountered in
 - **Multi-Format Support**: Converts and translates `PDF`, `DOCX`, `PPTX`, `HTML`, and `Image` formats into an **Interactive Viewer (HTML)**.
 - **Sentence-Level Parallel Translation**: Precisely matches one source sentence to one translated sentence for maximum readability.
 - **Layout Preservation**: Maintains tables and images within the document during translation.
-- **Flexible Engine Selection**: Supports Google Translate (Free), DeepL (High Quality), and Gemini (Context Aware).
+- **Flexible Engine Selection**: Supports Google Translate (Free), DeepL (High Quality), Gemini (Context Aware), and **OpenAI GPT-5-nano (Latest AI)**.
 - **High Performance**: Fast parallel processing for large volumes of documents using multi-threading (`max_workers`).
 
 ## Quick Start
@@ -47,7 +47,29 @@ python main.py sample.pdf
 
 # With options (Use DeepL engine, translate to Japanese)
 python main.py sample.pdf --engine deepl --to ja
+
+# Use OpenAI GPT-5-nano
+python main.py sample.pdf --engine openai --to ko
 ```
+
+### API Key Setup (Optional)
+
+To use DeepL, Gemini, or OpenAI, configure API keys in the `.env` file.
+
+```bash
+# Copy .env.example to .env
+cp .env.example .env
+
+# Edit .env file and add your API keys
+OPENAI_API_KEY=sk-proj-your-api-key-here
+DEEPL_API_KEY=your-deepl-key-here
+GEMINI_API_KEY=your-gemini-key-here
+```
+
+**API Key Links**:
+- [OpenAI API Keys](https://platform.openai.com/api-keys) - For GPT-5-nano ($0.05/1M input, $0.40/1M output tokens)
+- [DeepL API](https://www.deepl.com/pro-api)
+- [Google AI Studio](https://aistudio.google.com/app/apikey) - For Gemini
 
 ### 3. Web UI Usage
 

--- a/main.py
+++ b/main.py
@@ -772,7 +772,7 @@ def main():
     parser.add_argument("pdf_path", type=str, help="번역할 파일 또는 폴더의 경로")
     parser.add_argument('-f', '--from', dest='source_lang', type=str, default='en', help="번역할 원본 언어 코드 (기본값: en)")
     parser.add_argument('-t', '--to', dest='target_lang', type=str, default='ko', help="번역 결과물 언어 코드 (기본값: ko)")
-    parser.add_argument('-e', '--engine', dest='engine', type=str, choices=['google', 'deepl', 'gemini'], default='google', help="번역 엔진 선택")
+    parser.add_argument('-e', '--engine', dest='engine', type=str, choices=['google', 'deepl', 'gemini', 'openai'], default='google', help="번역 엔진 선택")
     parser.add_argument('--max-workers', type=int, default=8, help="병렬 처리를 위한 최대 워커 수 (기본값: 8)")
     
     # 벤치마크 옵션

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ nltk==3.9.1
 google-genai>=1.0.0
 deepl>=1.3.0
 python-dotenv>=1.0.0
-
+openai>=2.8.0
 streamlit>=1.30.0
 watchdog>=3.0.0


### PR DESCRIPTION
- Add OpenAI translation engine with GPT-5-nano model
- Implement global client singleton pattern for OpenAI and Gemini
- Add language code to full name mapping (LANGUAGE_NAMES)
- Optimize prompts with XML tags to prevent confusion
- Add automatic XML tag removal from responses
- Create .env.example for API key setup
- Update README (Korean/English) with OpenAI setup instructions
- Add openai>=2.8.0 to requirements.txt

Improves translation quality and consistency across all LLM engines.

Closes #47 