### PR TITLE
feat: Add text and code file translation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p> -->
 
 > **Docling 기반의 구조 보존형 문서 번역 도구**  
-> PDF, DOCX, PPTX, HTML, 이미지의 구조를 유지하며 인터랙티브 비교 뷰를 제공합니다.
+> PDF, DOCX, PPTX, HTML, 이미지, **코드 파일 및 텍스트 파일**의 구조를 유지하며 인터랙티브 비교 뷰를 제공합니다.
 
 [![Stars](https://img.shields.io/github/stars/gyunggyung/docling-translate?style=social)](https://github.com/gyunggyung/docling-translate/stargazers)
 [![Documentation Status](https://readthedocs.org/projects/docling-translate/badge/?version=latest)](https://docling-translate.readthedocs.io/ko/latest/?badge=latest)
@@ -32,9 +32,11 @@
 
 ## 주요 기능
 
-- **다양한 포맷 지원**: `PDF`, `DOCX`, `PPTX`, `HTML`, `Image` 포맷을 **인터랙티브 뷰어(HTML)** 형태로 변환 및 번역.
+- **다양한 포맷 지원**: `PDF`, `DOCX`, `PPTX`, `HTML`, `Image`, **텍스트/코드 파일**을 **인터랙티브 뷰어(HTML)** 형태로 변환 및 번역.
 - **문장 단위 병렬 번역**: 원문 한 문장, 번역문 한 문장을 정확히 매칭하여 가독성 극대화.
 - **레이아웃 보존**: 문서 내의 표(Table)와 이미지(Image)를 유지하며 번역.
+- **스마트 코드 번역**: 코드 파일(.py, .js, .ts, .java, .c, .go 등)의 **주석과 독스트링만 번역**하고 코드 구조는 그대로 유지.
+- **마크다운 렌더링**: 마크다운 파일은 제목, 리스트, 코드 블록 등이 제대로 렌더링된 HTML로 변환.
 - **유연한 엔진 선택**: Google Translate, DeepL, Gemini, OpenAI GPT-5-nano, Qwen(Local), LFM2(Local), LFM2-KOEN-MT(Local), NLLB-200(Local), NLLB-KOEN(Local), Yanolja(Local) 지원.
 - **고성능 처리**: 멀티스레딩(`max_workers`)을 통한 대량 문서 고속 병렬 처리.
 
@@ -105,6 +107,15 @@ python main.py sample.pdf --engine nllb --target ko
 
 # NLLB-KOEN 모델 사용 (한국어-영어 Fine-tuned, BLEU 33.66)
 python main.py sample.pdf --engine nllb-koen --target ko
+
+# 마크다운 파일 번역 (HTML로 렌더링)
+python main.py README.md --source en --target ko
+
+# Python 파일 번역 (주석/독스트링만 번역)
+python main.py script.py --source ko --target en
+
+# 텍스트 파일 번역
+python main.py notes.txt --source en --target ko
 ```
 
 ### API 키 설정 (선택 사항)
@@ -140,6 +151,27 @@ streamlit run app.py
 - **뷰 모드 제어**: 원문-번역문 대조 보기(Inspection Mode)와 번역문만 보기(Reading Mode)를 전환할 수 있습니다.
 - **실시간 진행률 표시**: 문서 변환, 텍스트 추출, 번역, 이미지 저장 등 각 단계별 상세 상태와 진행률을 실시간으로 확인할 수 있습니다.
 - **번역 기록 관리**: 이전 번역 결과를 자동으로 저장하고 불러올 수 있습니다.
+
+## 텍스트 및 코드 파일 번역
+
+문서 외에도 다양한 텍스트 기반 파일의 **스마트 번역**을 지원합니다:
+
+### 지원 파일 형식
+
+| 카테고리 | 확장자 | 번역 방식 |
+|----------|------------|---------------------|
+| **마크다운** | `.md`, `.markdown` | 전체 번역, HTML로 렌더링 |
+| **코드 파일** | `.py`, `.js`, `.ts`, `.java`, `.c`, `.cpp`, `.go`, `.rs` 등 | **주석/독스트링만** - 코드 구조 유지 |
+| **설정 파일** | `.json`, `.yaml`, `.toml`, `.xml` | 전체 번역 |
+| **일반 텍스트** | `.txt`, `.log` | 문단 단위 번역 |
+| **확장자 없음** | `LICENSE`, `README` 등 | 텍스트로 감지, 문단 단위 번역 |
+
+### 코드 파일 기능
+
+- **원본 코드 구조 유지** + 줄 번호 표시
+- **번역/원문 토글** 버튼으로 한 번에 전환
+- **마우스 호버** 시 원문 툴팁 표시
+- **다크/라이트 테마** 지원
 
 ## 아키텍처
 

--- a/app.py
+++ b/app.py
@@ -115,6 +115,13 @@ def main():
         [data-testid="stFileUploader"] section > div > div > span {{
             display: none;
         }}
+        /* Hide the ugly extension list in the uploader box */
+        [data-testid="stFileUploader"] section > div:first-child > small {{
+            display: none !important;
+        }}
+        [data-testid="stFileUploader"] section small {{
+            display: none !important;
+        }}
         /* Insert custom text */
         [data-testid="stFileUploader"] section > div > div::after {{
             content: "{t('uploader_text')}";
@@ -134,10 +141,23 @@ def main():
         label="file_uploader", # 고정 라벨 (화면엔 안 보임)
         label_visibility="collapsed",
         key="file_uploader", # 고정 Key
-        type=["pdf", "docx", "pptx", "html", "htm", "png", "jpg", "jpeg"],
+        type=[
+            # 기존 Docling 지원
+            "pdf", "docx", "pptx", "html", "htm", "png", "jpg", "jpeg",
+            # 텍스트/마크다운
+            "txt", "md", "markdown", "rst",
+            # 프로그래밍 언어 (주석 번역)
+            "py", "pyw", "js", "jsx", "ts", "tsx",
+            "c", "h", "cpp", "hpp", "cc", "cxx", "cs",
+            "java", "kt", "go", "rs", "swift",
+            "sh", "bash", "zsh",
+            # 설정 파일
+            "json", "yaml", "yml", "toml", "xml",
+            # 기타
+            "log", "cfg", "ini", "env",
+        ],
         accept_multiple_files=True
     )
-    st.caption(t("uploader_limit"))
 
     # 4. 번역 실행
     if uploaded_files:

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -5,7 +5,7 @@
 </p> -->
 
 > **Docling-based Translator for Technical Documents**  
-> Supports PDF, DOCX, PPTX, HTML & Images with interactive structure-preserving comparison.
+> Supports PDF, DOCX, PPTX, HTML, Images, **Code Files & Text Files** with interactive structure-preserving comparison.
 
 [![Stars](https://img.shields.io/github/stars/gyunggyung/docling-translate?style=social)](https://github.com/gyunggyung/docling-translate/stargazers)
 [![Documentation Status](https://readthedocs.org/projects/docling-translate/badge/?version=latest)](https://docling-translate.readthedocs.io/ko/latest/?badge=latest)
@@ -32,9 +32,11 @@ Designed to overcome the **imperfections and context loss** often encountered in
 
 ## Key Features
 
-- **Multi-Format Support**: Converts and translates `PDF`, `DOCX`, `PPTX`, `HTML`, and `Image` formats into an **Interactive Viewer (HTML)**.
+- **Multi-Format Support**: Converts and translates `PDF`, `DOCX`, `PPTX`, `HTML`, `Image`, and **Text/Code files** into an **Interactive Viewer (HTML)**.
 - **Sentence-Level Parallel Translation**: Precisely matches one source sentence to one translated sentence for maximum readability.
 - **Layout Preservation**: Maintains tables and images within the document during translation.
+- **Smart Code Translation**: For code files (.py, .js, .ts, .java, .c, .go, etc.), only comments and docstrings are translated while preserving the code structure.
+- **Markdown Rendering**: Markdown files are rendered as HTML with proper formatting (headings, lists, code blocks, etc.).
 - **Flexible Engine Selection**: Supports Google Translate, DeepL, Gemini, OpenAI GPT-5-nano, Qwen(Local), LFM2(Local), LFM2-KOEN-MT(Local), NLLB-200(Local), Yanolja(Local).
 - **High Performance**: Fast parallel processing for large volumes of documents using multi-threading (`max_workers`).
 
@@ -102,6 +104,15 @@ python main.py sample.pdf --engine lfm2-koen-mt --target ko
 
 # Use NLLB-200 model (200 languages support)
 python main.py sample.pdf --engine nllb --target ko
+
+# Translate a Markdown file (rendered as HTML)
+python main.py README.md --source en --target ko
+
+# Translate a Python file (comments/docstrings only)
+python main.py script.py --source ko --target en
+
+# Translate a text file
+python main.py notes.txt --source en --target ko
 ```
 
 ### API Key Setup (Optional)
@@ -137,6 +148,27 @@ streamlit run app.py
 - **View Mode Control**: Switch between "Inspection Mode" (Side-by-Side) and "Reading Mode" (Translation Only).
 - **Real-time Progress**: View detailed status and real-time progress for each step, including document conversion, text extraction, translation, and image saving.
 - **History Management**: Automatically saves and loads previous translation results.
+
+## Text & Code File Translation
+
+In addition to documents, `docling-translate` supports **smart translation** for various text-based files:
+
+### Supported File Types
+
+| Category | Extensions | Translation Behavior |
+|----------|------------|---------------------|
+| **Markdown** | `.md`, `.markdown` | Full text translated, rendered as HTML |
+| **Code Files** | `.py`, `.js`, `.ts`, `.java`, `.c`, `.cpp`, `.go`, `.rs`, etc. | **Comments & docstrings only** - code structure preserved |
+| **Config Files** | `.json`, `.yaml`, `.toml`, `.xml` | Full content translated |
+| **Plain Text** | `.txt`, `.log` | Full text translated by paragraph |
+| **No Extension** | `LICENSE`, `README`, etc. | Detected as text, translated by paragraph |
+
+### Code File Features
+
+- **Original code structure preserved** with line numbers
+- **Toggle between translated/original comments** with a single click
+- **Hover over translated comments** to see the original text in a tooltip
+- **Dark/Light theme** support
 
 ## Architecture
 

--- a/main.py
+++ b/main.py
@@ -8,8 +8,15 @@ Docling PDF 번역기의 CLI(Command Line Interface) 진입점입니다.
 2.  **문서 처리 요청**: `src.core.process_document`를 호출하여 문서 변환 및 번역을 실행합니다.
 3.  **결과 출력**: 처리 결과를 콘솔에 출력합니다.
 
+지원 파일 형식:
+- 문서: PDF, DOCX, PPTX, HTML, Image
+- 텍스트: .md, .txt, .json, .yaml 등
+- 코드: .py, .js, .ts, .java, .c, .go 등 (주석/독스트링만 번역)
+
 사용 예시:
     python main.py document.pdf --source en --target ko --engine google
+    python main.py README.md --source en --target ko
+    python main.py script.py --source ko --target en
 """
 
 import argparse
@@ -33,7 +40,7 @@ def main():
     parser = argparse.ArgumentParser(description="Docling PDF Translator CLI")
     
     # 필수 인수: 입력 파일 경로
-    parser.add_argument("input_file", help="Path to the input file (PDF, DOCX, PPTX, etc.)")
+    parser.add_argument("input_file", help="Path to the input file (PDF, DOCX, PPTX, HTML, Image, .md, .py, .txt, etc.)")
     
     # 선택 인수
     parser.add_argument("--source", default="en", help="Source language code (default: en)")

--- a/plans/issue-97-text-file-smart-translation.md
+++ b/plans/issue-97-text-file-smart-translation.md
@@ -1,0 +1,400 @@
+# Issue #97: 텍스트 파일 번역 기능 추가
+
+## 목표
+
+txt, md, py, js, c, go, json, yaml 등 일반 텍스트 파일과 확장자가 없는 파일(LICENSE 등)을 업로드하여 **스마트 번역**할 수 있는 기능을 추가합니다. 파일 타입별로 번역 대상 영역을 지능적으로 선택하여 코드는 주석만, 마크다운은 코드블록 제외 등의 처리를 수행합니다.
+
+**관련 이슈**: https://github.com/gyunggyung/docling-translate/issues/97
+
+## 배경
+
+현재 프로젝트는 Docling 라이브러리를 사용하여 PDF, DOCX, PPTX, HTML, 이미지만 지원합니다. 그러나 사용자들은 README.md, LICENSE, 소스 코드 파일 등의 텍스트 파일도 번역하고 싶어합니다. 
+
+단순 텍스트 번역이 아닌 **스마트 번역**이 필요한 이유:
+- 코드 파일에서 코드 자체는 번역하면 실행 불가
+- 마크다운에서 코드 블록은 번역하면 의미 왜곡
+- 원문은 반드시 유지하고 번역문과 함께 표시 필요
+
+## 제안 변경 사항
+
+### 1. 텍스트 파일 파서 모듈 (신규)
+
+#### [NEW] [text_parser.py](file:///c:/github/docling-translate/src/text_parser.py)
+
+**목적**: 텍스트 파일 타입별로 번역 대상 영역을 지능적으로 추출
+
+**주요 기능**:
+
+```python
+from dataclasses import dataclass
+from typing import List, Tuple
+from pathlib import Path
+import re
+
+@dataclass
+class TextSegment:
+    """번역 가능한 텍스트 조각"""
+    text: str           # 원본 텍스트
+    start_pos: int      # 파일 내 시작 위치
+    end_pos: int        # 파일 내 끝 위치
+    translatable: bool  # 번역 대상 여부
+    segment_type: str   # 'prose', 'comment', 'code', 'header', 'string' 등
+
+class TextFileParser:
+    """텍스트 파일을 파싱하여 번역 대상 영역을 추출합니다."""
+    
+    # 지원하는 파일 타입과 해당 파서
+    PARSERS = {
+        'markdown': ['md', 'markdown', 'rst'],
+        'python': ['py', 'pyw'],
+        'javascript': ['js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs'],
+        'c_family': ['c', 'h', 'cpp', 'hpp', 'cc', 'cxx', 'cs', 'java', 'kt', 'swift'],
+        'go': ['go'],
+        'rust': ['rs'],
+        'shell': ['sh', 'bash', 'zsh', 'fish'],
+        'config': ['json', 'yaml', 'yml', 'toml', 'xml'],
+        'plaintext': ['txt', 'text', 'log', ''],  # 확장자 없음 포함
+    }
+    
+    def parse(self, file_path: Path) -> List[TextSegment]:
+        """파일을 파싱하여 세그먼트 리스트 반환"""
+        ext = file_path.suffix.lstrip('.').lower()
+        parser_type = self._detect_parser_type(ext)
+        
+        content = file_path.read_text(encoding='utf-8')
+        
+        if parser_type == 'markdown':
+            return self._parse_markdown(content)
+        elif parser_type == 'python':
+            return self._parse_python(content)
+        elif parser_type in ['javascript', 'c_family', 'go', 'rust', 'java']:
+            return self._parse_c_style(content)  # // 및 /* */ 주석
+        elif parser_type == 'shell':
+            return self._parse_shell(content)  # # 주석
+        elif parser_type == 'config':
+            return self._parse_config(content)
+        else:
+            return self._parse_plaintext(content)
+```
+
+**파일 타입별 번역 규칙**:
+
+| 파일 타입 | 확장자 | 번역 대상 | 제외 대상 |
+|-----------|--------|-----------|-----------|
+| **마크다운** | .md, .markdown, .rst | 본문, 헤더, 리스트 | 코드블록 (```), 인라인 코드 (`) |
+| **파이썬** | .py | 주석 (#), 독스트링 ("""/''') | 코드 |
+| **C 계열** | .c, .cpp, .h, .java, .cs, .kt, .swift | 주석 (//, /* */) | 코드 |
+| **자바스크립트** | .js, .ts, .jsx, .tsx | 주석 (//, /* */) | 코드 |
+| **Go** | .go | 주석 (//, /* */) | 코드 |
+| **Rust** | .rs | 주석 (//, /* */, ///) | 코드 |
+| **쉘 스크립트** | .sh, .bash | 주석 (#) | 코드 |
+| **설정 파일** | .json, .yaml, .yml, .toml | 전체 (키 + 값) | 없음 |
+| **일반 텍스트** | .txt, LICENSE, README | 전체 | 없음 |
+
+---
+
+### 2. 텍스트 파일 HTML 생성기 (신규)
+
+#### [NEW] [text_html_generator.py](file:///c:/github/docling-translate/src/text_html_generator.py)
+
+**목적**: 텍스트 파일의 번역 결과를 기존 HTML 뷰어와 동일한 형식으로 생성
+
+**주요 기능**:
+- 원문/번역문 양쪽 표시 (기존 방식 유지)
+- 번역 불가 영역(코드)은 원문만 표시하고 코드 스타일로 구분
+- 기존 `html_generator.py`의 CSS/JS 재사용
+- 구문 하이라이팅 (선택적: Prism.js 또는 Highlight.js 사용)
+
+```python
+def generate_text_html(
+    file_name: str,
+    segments: List[TextSegment],
+    translation_map: dict,
+    output_dir: Path,
+) -> str:
+    """텍스트 파일 번역 결과 HTML 생성
+    
+    Args:
+        file_name: 원본 파일명
+        segments: 파싱된 텍스트 세그먼트 리스트
+        translation_map: 원문 -> 번역문 매핑
+        output_dir: 출력 디렉토리
+    
+    Returns:
+        HTML 문자열
+    """
+    # 기존 HTML 헤더/푸터 재사용
+    # 세그먼트별로:
+    #   - translatable=True: 원문 + 번역문 양쪽 표시
+    #   - translatable=False: 원문만 표시 (코드 스타일, 회색 배경)
+```
+
+**HTML 출력 구조**:
+```html
+<!-- 번역 가능한 세그먼트 (주석, 문서) -->
+<div class="text-block translatable">
+  <div class="src-block"># This is a comment</div>
+  <div class="tgt-block"># 이것은 주석입니다</div>
+</div>
+
+<!-- 번역 불가 세그먼트 (코드) -->
+<div class="text-block code-only">
+  <pre><code>def hello_world():
+    print("Hello")</code></pre>
+</div>
+```
+
+---
+
+### 3. 코어 모듈 확장
+
+#### [MODIFY] [core.py](file:///c:/github/docling-translate/src/core.py)
+
+**변경 내용**:
+- `process_single_file` 함수에서 파일 타입 감지 추가
+- 텍스트 파일인 경우 `process_text_file` 분기 처리
+- Docling Converter 없이도 텍스트 파일 처리 가능하도록
+
+```python
+# 새로운 상수
+TEXT_EXTENSIONS = {
+    # 마크다운/문서
+    '.md', '.markdown', '.rst', '.txt', '.text',
+    # 프로그래밍 언어
+    '.py', '.pyw',                    # Python
+    '.js', '.jsx', '.ts', '.tsx',     # JavaScript/TypeScript
+    '.c', '.h', '.cpp', '.hpp', '.cc', '.cxx',  # C/C++
+    '.cs',                            # C#
+    '.java', '.kt',                   # Java/Kotlin
+    '.go',                            # Go
+    '.rs',                            # Rust
+    '.swift',                         # Swift
+    '.sh', '.bash', '.zsh',           # Shell
+    # 설정 파일
+    '.json', '.yaml', '.yml', '.toml', '.xml',
+    # 기타
+    '.log', '.cfg', '.ini', '.env',
+}
+
+def is_text_file(file_path: str) -> bool:
+    """텍스트 파일 여부 확인 (확장자 및 바이너리 체크)"""
+    ext = Path(file_path).suffix.lower()
+    if ext in TEXT_EXTENSIONS:
+        return True
+    # 확장자 없는 파일은 바이너리 체크
+    if not ext:
+        return not _is_binary(file_path)
+    return False
+
+def _is_binary(file_path: str) -> bool:
+    """파일이 바이너리인지 확인 (null byte 존재 여부)"""
+    with open(file_path, 'rb') as f:
+        chunk = f.read(8192)
+        return b'\x00' in chunk
+
+def process_text_file(
+    file_path: str,
+    source_lang: str,
+    target_lang: str,
+    engine: str,
+    max_workers: int,
+    progress_cb: Optional[ProgressCallback] = None,
+    ui_lang: str = "ko"
+) -> dict:
+    """텍스트 파일 전용 처리 파이프라인
+    
+    1. 파일 파싱 (세그먼트 추출)
+    2. 번역 대상 세그먼트 수집
+    3. 일괄 번역
+    4. HTML 생성
+    """
+    pass
+```
+
+**process_single_file 수정**:
+```python
+def process_single_file(...):
+    # 파일 타입 체크 추가
+    if is_text_file(file_path):
+        return process_text_file(
+            file_path=file_path,
+            source_lang=source_lang,
+            target_lang=target_lang,
+            engine=engine,
+            max_workers=max_workers,
+            progress_cb=progress_cb,
+            ui_lang=ui_lang
+        )
+    
+    # 기존 Docling 처리 로직
+    doc: DoclingDocument = converter.convert(file_path).document
+    ...
+```
+
+---
+
+### 4. 웹 UI 확장
+
+#### [MODIFY] [app.py](file:///c:/github/docling-translate/app.py)
+
+**변경 내용**:
+- 파일 업로더의 `type` 목록에 텍스트 확장자 추가
+
+```python
+# 변경 전
+type=["pdf", "docx", "pptx", "html", "htm", "png", "jpg", "jpeg"],
+
+# 변경 후
+type=[
+    # 기존 Docling 지원
+    "pdf", "docx", "pptx", "html", "htm", "png", "jpg", "jpeg",
+    # 텍스트/마크다운
+    "txt", "md", "markdown", "rst",
+    # 프로그래밍 언어 (주석 번역)
+    "py", "js", "jsx", "ts", "tsx", "c", "h", "cpp", "hpp", "cs", 
+    "java", "kt", "go", "rs", "swift", "sh", "bash",
+    # 설정 파일
+    "json", "yaml", "yml", "toml", "xml",
+],
+```
+
+> **참고**: Streamlit의 `file_uploader`는 확장자 없는 파일을 자동으로 지원합니다. 
+> `type` 리스트에 없어도 파일을 드래그하면 업로드 가능합니다.
+
+---
+
+### 5. CLI 확장
+
+#### [MODIFY] [main.py](file:///c:/github/docling-translate/main.py)
+
+**변경 내용**:
+- 텍스트 파일 지원 추가
+- 도움말 메시지에 지원 형식 업데이트
+
+```python
+# 도움말 메시지 업데이트
+HELP_TEXT = """
+지원 형식:
+  - 문서: PDF, DOCX, PPTX, HTML
+  - 이미지: PNG, JPG, JPEG
+  - 텍스트: TXT, MD, RST (전체 번역)
+  - 코드: PY, JS, TS, C, CPP, GO, RS (주석만 번역)
+  - 설정: JSON, YAML, TOML (전체 번역)
+"""
+```
+
+---
+
+## 검증 계획
+
+### 1. 수동 테스트
+
+**시나리오 1: 마크다운 파일**
+- 파일: `README.md`
+- 예상 결과: 
+  - 본문 텍스트는 번역됨
+  - 코드 블록(```python ... ```)은 원문 유지
+  - 인라인 코드(`function_name`)는 원문 유지
+
+**시나리오 2: 파이썬 파일**
+- 파일: `main.py`
+- 예상 결과:
+  - `#` 주석과 `"""` 독스트링만 번역됨
+  - 코드 자체는 원문 유지
+
+**시나리오 3: C/C++ 파일**
+- 파일: 샘플 `.c` 또는 `.cpp` 파일
+- 예상 결과:
+  - `//` 한 줄 주석 번역됨
+  - `/* */` 여러 줄 주석 번역됨
+  - 코드는 원문 유지
+
+**시나리오 4: Go 파일**
+- 파일: 샘플 `.go` 파일
+- 예상 결과:
+  - `//` 주석 번역됨
+  - 코드는 원문 유지
+
+**시나리오 5: 설정 파일 (JSON/YAML)**
+- 파일: 샘플 `.json` 또는 `.yaml`
+- 예상 결과:
+  - 키와 값 모두 번역됨
+  - JSON/YAML 구조는 유지
+
+**시나리오 6: 확장자 없는 파일**
+- 파일: `LICENSE`
+- 예상 결과:
+  - 전체 텍스트가 번역됨
+
+**시나리오 7: 기존 PDF 파일 (회귀 테스트)**
+- 파일: `samples/1706.03762v7.pdf`
+- 예상 결과: 기존과 동일하게 작동 (회귀 없음)
+
+### 2. 검증 체크리스트
+
+- [ ] 마크다운 코드블록 제외 번역
+- [ ] 마크다운 인라인 코드 제외 번역
+- [ ] 파이썬 주석/독스트링만 번역
+- [ ] C 계열 언어 주석만 번역 (C, C++, Java, C#, Go, Rust, Swift)
+- [ ] 자바스크립트/타입스크립트 주석만 번역
+- [ ] 쉘 스크립트 주석만 번역
+- [ ] JSON/YAML 전체 번역 (키 + 값)
+- [ ] 확장자 없는 파일 처리
+- [ ] 바이너리 파일 거부
+- [ ] 원문/번역문 HTML 정상 표시
+- [ ] 코드 영역 스타일 구분
+- [ ] 표준 샘플(`samples/1706.03762v7.pdf`)로 회귀 테스트
+- [ ] 기존 기능이 정상 동작하는지 확인
+
+---
+
+## 예상 효과
+
+- **사용성**: README, LICENSE, 소스 코드 등 다양한 파일 번역 가능
+- **품질**: 코드는 보존하면서 주석/문서만 정확히 번역
+- **확장성**: 새로운 파일 타입 파서를 쉽게 추가 가능한 구조
+- **개발자 친화적**: 외국어 오픈소스 코드의 주석을 쉽게 이해 가능
+
+---
+
+## 주의사항
+
+- **인코딩 문제**: UTF-8 외 인코딩 파일 처리 시 오류 가능 (chardet 사용 고려)
+- **대용량 파일**: 매우 큰 텍스트 파일은 메모리 문제 발생 가능 (청크 처리 필요)
+- **정규식 한계**: 복잡한 코드 구조(중첩 주석, 문자열 내 주석 등)는 완벽히 파싱 어려울 수 있음
+- **JSON 번역 주의**: JSON 키를 번역하면 프로그램에서 읽을 때 문제 발생 가능 (사용자에게 경고 필요)
+
+---
+
+## 구현 순서
+
+1. **Phase 1**: `text_parser.py` 구현
+   - 기본 클래스 구조
+   - 마크다운 파서 (코드블록, 인라인 코드 제외)
+   - 파이썬 파서 (주석, 독스트링)
+   - C 스타일 파서 (JS, C, C++, Go, Rust, Java 등)
+   - 쉘 스크립트 파서
+   - 설정 파일 파서 (JSON, YAML)
+   - 일반 텍스트 파서
+
+2. **Phase 2**: `text_html_generator.py` 구현
+   - HTML 템플릿 (기존 스타일 재사용)
+   - 세그먼트별 렌더링
+   - 코드 영역 스타일링
+
+3. **Phase 3**: `core.py` 수정
+   - `is_text_file()` 함수
+   - `process_text_file()` 함수
+   - `process_single_file()` 분기 로직
+
+4. **Phase 4**: UI/CLI 확장
+   - `app.py` 파일 타입 추가
+   - `main.py` 도움말 업데이트
+
+5. **Phase 5**: 테스트 및 문서화
+   - 각 파일 타입별 테스트
+   - README 업데이트
+
+---
+
+*계획 작성일: 2026-01-01*

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv>=1.0.0
 openai>=2.8.0
 streamlit>=1.30.0
 watchdog>=3.0.0
+markdown>=3.5.0

--- a/src/i18n.py
+++ b/src/i18n.py
@@ -22,12 +22,12 @@ TRANSLATIONS = {
 
         # 업로더 텍스트 (CSS Hack용)
         "uploader_text": "Drag and drop files here",
-        "uploader_limit": "Limit 50GB per file • PDF, DOCX, PPTX, HTML, HTM, PNG, JPG, JPEG",
+        "uploader_limit": "Docs: PDF, DOCX, PPTX | Code: .py, .js, .ts, .java, .c, .go | Text: .md, .txt, .json",
 
         # 타이틀 / 사이드바
         "app_title": "Docling PDF Translator",
         "sidebar_header": "Settings",
-        "upload_label": "Upload documents (PDF, DOCX, PPTX, HTML, Image, etc.)",
+        "upload_label": "Upload files (Documents, Code, Text)",
         "options_label": "Translation options",
         "src_label": "Source language",
         "dest_label": "Target language",
@@ -89,12 +89,12 @@ TRANSLATIONS = {
 
         # 업로더 텍스트 (CSS Hack용)
         "uploader_text": "파일을 이곳에 드래그 앤 드롭하세요",
-        "uploader_limit": "파일당 50GB 제한 • PDF, DOCX, PPTX, HTML, HTM, PNG, JPG, JPEG",
+        "uploader_limit": "문서: PDF, DOCX, PPTX | 코드: .py, .js, .ts, .java, .c, .go | 텍스트: .md, .txt, .json",
 
         # 타이틀 / 사이드바
         "app_title": "Docling PDF 번역기",
         "sidebar_header": "설정",
-        "upload_label": "문서 업로드 (PDF, DOCX, PPTX, HTML, Image 등)",
+        "upload_label": "파일 업로드 (문서, 코드, 텍스트)",
         "options_label": "번역 옵션",
         "src_label": "원본 언어 (Source)",
         "dest_label": "대상 언어 (Target)",

--- a/src/text_html_generator.py
+++ b/src/text_html_generator.py
@@ -1,0 +1,890 @@
+"""
+src/text_html_generator.py
+==========================
+텍스트 파일 번역 결과를 인터랙티브한 HTML 파일로 생성하는 모듈입니다.
+
+이 모듈은 다음 기능을 수행합니다:
+1.  **HTML 구조 정의**: 기존 html_generator.py와 동일한 CSS/JS 스타일을 재사용합니다.
+2.  **세그먼트별 렌더링**: 번역 가능/불가능 영역을 구분하여 표시합니다.
+3.  **마크다운 렌더링**: 마크다운 파일은 실제 HTML로 렌더링합니다.
+4.  **코드 하이라이팅**: 번역 불가 영역(코드)은 별도 스타일로 표시합니다.
+"""
+
+import html
+import markdown
+from pathlib import Path
+from typing import List, Optional, Callable
+
+from src.text_parser import TextSegment
+
+# 진행률 콜백 타입 정의
+ProgressCallback = Callable[[float, str], None]
+
+# 마크다운 컨버터 초기화 (확장 기능 포함)
+md_converter = markdown.Markdown(extensions=['fenced_code', 'tables', 'nl2br'])
+
+# HTML 헤더: CSS 스타일 및 자바스크립트 포함
+# 기존 html_generator.py와 동일한 스타일을 사용하되, 코드 영역 스타일 추가
+TEXT_HTML_HEADER = """
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Docling Translation Result - Text File</title>
+    <style>
+        :root {
+            --bg-color: #f4f6f8;
+            --card-bg: #ffffff;
+            --text-color: #222222;
+            --sub-text-color: #666666;
+            --border-color: #eeeeee;
+            --hover-color: #eef7ff;
+            --btn-bg: #ffffff;
+            --btn-text: #333333;
+            --btn-border: #dddddd;
+            --btn-hover-bg: #f0f0f0;
+            --shadow: 0 2px 5px rgba(0,0,0,0.05);
+            --highlight-bg: rgba(255, 255, 0, 0.3);
+            --active-bg: rgba(0, 123, 255, 0.1);
+            --related-bg: rgba(0, 123, 255, 0.15);
+            --code-bg: #f6f8fa;
+            --code-border: #e1e4e8;
+        }
+        [data-theme="dark"] {
+            --bg-color: #1a1a1a;
+            --card-bg: #2d2d2d;
+            --text-color: #e0e0e0;
+            --sub-text-color: #aaaaaa;
+            --border-color: #404040;
+            --hover-color: #3d3d3d;
+            --btn-bg: #3d3d3d;
+            --btn-text: #e0e0e0;
+            --btn-border: #555555;
+            --btn-hover-bg: #4d4d4d;
+            --shadow: 0 2px 5px rgba(0,0,0,0.2);
+            --highlight-bg: rgba(255, 255, 0, 0.3);
+            --active-bg: rgba(0, 123, 255, 0.2);
+            --related-bg: rgba(0, 123, 255, 0.25);
+            --code-bg: #1e1e1e;
+            --code-border: #3d3d3d;
+        }
+        
+        body { font-family: 'Segoe UI', sans-serif; background: var(--bg-color); color: var(--text-color); margin: 0; padding: 20px; transition: background 0.3s, color 0.3s; }
+        
+        .controls { 
+            display: flex; 
+            justify-content: flex-end; 
+            gap: 10px; 
+            margin-bottom: 20px; 
+            position: sticky; 
+            top: 10px; 
+            z-index: 1000; 
+            background: var(--bg-color);
+            padding: 10px;
+            border-radius: 8px;
+            box-shadow: var(--shadow);
+            opacity: 0.95;
+            backdrop-filter: blur(5px);
+        }
+        
+        .btn { 
+            padding: 8px 16px; 
+            background: var(--btn-bg); 
+            color: var(--btn-text); 
+            border: 1px solid var(--btn-border); 
+            border-radius: 20px; 
+            cursor: pointer; 
+            box-shadow: var(--shadow); 
+            font-size: 0.9em;
+            transition: all 0.2s;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .btn:hover { background: var(--btn-hover-bg); }
+        .btn.active { background-color: var(--active-bg); border-color: #007bff; color: #007bff; }
+        
+        .container { 
+            max-width: 1200px; 
+            margin: 0 auto; 
+            background: var(--card-bg); 
+            box-shadow: var(--shadow); 
+            border-radius: 8px; 
+            padding: 40px;
+            overflow: hidden; 
+            transition: background 0.3s;
+        }
+        
+        .file-info {
+            background: var(--hover-color);
+            padding: 15px 20px;
+            border-radius: 8px;
+            margin-bottom: 30px;
+            font-size: 0.9em;
+        }
+        .file-info .filename {
+            font-weight: bold;
+            font-size: 1.1em;
+            margin-bottom: 5px;
+        }
+        .file-info .meta {
+            color: var(--sub-text-color);
+        }
+        
+        /* 세그먼트 블록 */
+        .segment-row {
+            margin-bottom: 20px;
+            line-height: 1.8;
+            position: relative;
+        }
+        
+        /* 코드 블록 스타일 (번역 불가 영역) */
+        .code-segment {
+            background: var(--code-bg);
+            border: 1px solid var(--code-border);
+            border-radius: 6px;
+            padding: 16px;
+            font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+            font-size: 0.9em;
+            overflow-x: auto;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            margin: 15px 0;
+        }
+        
+        .code-segment .code-label {
+            display: inline-block;
+            background: var(--border-color);
+            color: var(--sub-text-color);
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 0.75em;
+            margin-bottom: 10px;
+            font-family: 'Segoe UI', sans-serif;
+        }
+        
+        /* 읽기 모드 (기본) */
+        .src-block { display: none; }
+        .tgt-block { color: var(--text-color); }
+        
+        .sent {
+            cursor: pointer;
+            border-radius: 3px;
+            transition: background 0.2s;
+        }
+        .sent:hover { background-color: var(--active-bg); }
+        .sent.highlight { background-color: var(--highlight-bg); }
+        .sent.related-highlight { background-color: var(--related-bg); }
+
+        /* 툴팁 */
+        .sent[data-src-text]:hover::after {
+            content: attr(data-src-text);
+            position: absolute;
+            left: 0;
+            right: 0;
+            bottom: 100%;
+            background: #333;
+            color: #fff;
+            padding: 8px 12px;
+            border-radius: 4px;
+            font-size: 0.9em;
+            z-index: 1000;
+            white-space: normal;
+            box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+            pointer-events: none;
+            margin-bottom: 5px;
+        }
+        
+        /* 검수 모드 (Side-by-Side) */
+        .view-mode-inspect .segment-row:not(.code-segment-wrapper) {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+            margin-bottom: 30px;
+            padding-bottom: 20px;
+            border-bottom: 1px dashed var(--border-color);
+        }
+        
+        .view-mode-inspect .src-block { 
+            display: block; 
+            color: var(--sub-text-color); 
+            font-size: 0.95em;
+        }
+        
+        .view-mode-inspect .sent {
+            display: block;
+            margin-bottom: 8px;
+            padding: 4px;
+        }
+        
+        .view-mode-inspect .sent[data-src]:hover::after {
+            display: none;
+        }
+
+        /* 주석 스타일 */
+        .comment-segment {
+            color: #6a737d;
+            font-style: italic;
+        }
+        
+        .docstring-segment {
+            color: #22863a;
+        }
+
+        /* 마크다운 렌더링 스타일 */
+        .md-content h1 { font-size: 2em; border-bottom: 1px solid var(--border-color); padding-bottom: 0.3em; margin: 1em 0 0.5em 0; }
+        .md-content h2 { font-size: 1.5em; border-bottom: 1px solid var(--border-color); padding-bottom: 0.3em; margin: 1em 0 0.5em 0; }
+        .md-content h3 { font-size: 1.25em; margin: 1em 0 0.5em 0; }
+        .md-content h4 { font-size: 1em; margin: 1em 0 0.5em 0; }
+        .md-content p { margin: 0.5em 0; line-height: 1.8; }
+        .md-content ul, .md-content ol { margin: 0.5em 0; padding-left: 2em; }
+        .md-content li { margin: 0.3em 0; }
+        .md-content code { 
+            background: var(--code-bg); 
+            padding: 2px 6px; 
+            border-radius: 4px; 
+            font-family: 'Consolas', 'Monaco', monospace;
+            font-size: 0.9em;
+        }
+        .md-content pre { 
+            background: var(--code-bg); 
+            border: 1px solid var(--code-border);
+            border-radius: 6px; 
+            padding: 16px; 
+            overflow-x: auto; 
+        }
+        .md-content pre code { background: transparent; padding: 0; }
+        .md-content blockquote { 
+            border-left: 4px solid #007bff; 
+            margin: 1em 0; 
+            padding: 0.5em 1em; 
+            background: var(--hover-color);
+            color: var(--sub-text-color);
+        }
+        .md-content a { color: #007bff; text-decoration: none; }
+        .md-content a:hover { text-decoration: underline; }
+        .md-content table { border-collapse: collapse; width: 100%; margin: 1em 0; }
+        .md-content th, .md-content td { border: 1px solid var(--border-color); padding: 8px 12px; text-align: left; }
+        .md-content th { background: var(--hover-color); }
+        .md-content img { max-width: 100%; height: auto; }
+        .md-content strong { font-weight: 600; }
+        .md-content em { font-style: italic; }
+
+        /* 모바일 반응형 */
+        @media (max-width: 768px) {
+            .view-mode-inspect .segment-row { grid-template-columns: 1fr; }
+            .container { padding: 20px; }
+        }
+    </style>
+    <script>
+        const UI_STRINGS = {
+            en: {
+                theme_dark: "Dark Mode",
+                theme_light: "Light Mode",
+                mode_read: "Reading Mode",
+                mode_inspect: "Inspection Mode",
+                lang_ui: "한국어",
+                title: "Text Translation Result"
+            },
+            ko: {
+                theme_dark: "다크 모드",
+                theme_light: "라이트 모드",
+                mode_read: "읽기 모드",
+                mode_inspect: "검수 모드",
+                lang_ui: "English",
+                title: "텍스트 번역 결과"
+            }
+        };
+
+        let currentUiLang = 'ko';
+        
+        function init() {
+            const savedTheme = localStorage.getItem('theme') || 'light';
+            document.body.setAttribute('data-theme', savedTheme);
+            updateUiText();
+            setupHighlighting();
+        }
+
+        function toggleTheme() {
+            const body = document.body;
+            const current = body.getAttribute('data-theme');
+            const next = current === 'dark' ? 'light' : 'dark';
+            body.setAttribute('data-theme', next);
+            localStorage.setItem('theme', next);
+            updateUiText();
+        }
+
+        function toggleMode() {
+            const container = document.getElementById('content-container');
+            const btn = document.getElementById('btn-mode');
+            
+            if (container.classList.contains('view-mode-inspect')) {
+                container.classList.remove('view-mode-inspect');
+                btn.classList.remove('active');
+            } else {
+                container.classList.add('view-mode-inspect');
+                btn.classList.add('active');
+            }
+            updateUiText();
+        }
+        
+        function toggleUiLang() {
+            currentUiLang = currentUiLang === 'ko' ? 'en' : 'ko';
+            updateUiText();
+        }
+
+        function updateUiText() {
+            const t = UI_STRINGS[currentUiLang];
+            const isDark = document.body.getAttribute('data-theme') === 'dark';
+            const isInspect = document.getElementById('content-container').classList.contains('view-mode-inspect');
+            
+            document.getElementById('btn-theme').innerText = isDark ? t.theme_light : t.theme_dark;
+            document.getElementById('btn-mode').innerText = isInspect ? t.mode_read : t.mode_inspect;
+            document.getElementById('btn-lang').innerText = t.lang_ui;
+            document.getElementById('page-title').innerText = t.title;
+        }
+
+        function setupHighlighting() {
+            const sents = document.querySelectorAll('.sent');
+            sents.forEach(el => {
+                el.addEventListener('mouseover', function() {
+                    const id = this.id;
+                    if (!id) return;
+                    
+                    const parts = id.split('-');
+                    const type = parts[0];
+                    const itemId = parts[1];
+                    const idx = parts[2];
+                    
+                    const targetType = type === 'src' ? 'tgt' : 'src';
+                    const targetId = `${targetType}-${itemId}-${idx}`;
+                    
+                    const targetEl = document.getElementById(targetId);
+                    if (targetEl) {
+                        targetEl.classList.add('related-highlight');
+                    }
+                });
+                
+                el.addEventListener('mouseout', function() {
+                    const id = this.id;
+                    if (!id) return;
+                    
+                    const parts = id.split('-');
+                    const type = parts[0];
+                    const itemId = parts[1];
+                    const idx = parts[2];
+                    
+                    const targetType = type === 'src' ? 'tgt' : 'src';
+                    const targetId = `${targetType}-${itemId}-${idx}`;
+                    
+                    const targetEl = document.getElementById(targetId);
+                    if (targetEl) {
+                        targetEl.classList.remove('related-highlight');
+                    }
+                });
+            });
+        }
+        
+        window.onload = init;
+    </script>
+</head>
+<body>
+    <div class="controls">
+        <button id="btn-theme" class="btn" onclick="toggleTheme()">다크 모드</button>
+        <button id="btn-mode" class="btn" onclick="toggleMode()">검수 모드</button>
+        <button id="btn-lang" class="btn" onclick="toggleUiLang()">English</button>
+    </div>
+    <h1 id="page-title" style="text-align: center; margin-bottom: 40px;">텍스트 번역 결과</h1>
+    <div id="content-container" class="container">
+"""
+
+TEXT_HTML_FOOTER = """
+    </div> <!-- Close content-container -->
+</body>
+</html>
+"""
+
+
+def generate_text_html(
+    file_name: str,
+    segments: List[TextSegment],
+    translation_map: dict,
+    file_type: str = "text",
+    is_markdown: bool = False,
+    progress_cb: Optional[ProgressCallback] = None
+) -> str:
+    """
+    텍스트 파일의 세그먼트와 번역 맵을 결합하여 인터랙티브 HTML을 생성합니다.
+    
+    Args:
+        file_name: 원본 파일명
+        segments: TextSegment 리스트
+        translation_map: 원문 텍스트 -> 번역 텍스트 매핑
+        file_type: 파일 타입 (표시용)
+        is_markdown: 마크다운 파일 여부 (True면 HTML로 렌더링)
+        progress_cb: 진행률 콜백
+        
+    Returns:
+        완성된 HTML 문자열
+    """
+    html_parts = [TEXT_HTML_HEADER]
+    
+    # 파일 정보 표시
+    segment_count = len(segments)
+    translatable_count = sum(1 for s in segments if s.translatable)
+    
+    html_parts.append(f"""
+    <div class="file-info">
+        <div class="filename">📄 {html.escape(file_name)}</div>
+        <div class="meta">파일 타입: {html.escape(file_type)} | 세그먼트: {segment_count}개 | 번역 대상: {translatable_count}개</div>
+    </div>
+    """)
+    
+    # 세그먼트 처리
+    total_segments = len(segments)
+    
+    for idx, segment in enumerate(segments):
+        # 진행률 업데이트
+        if progress_cb and idx % 10 == 0:
+            ratio = idx / total_segments if total_segments > 0 else 1.0
+            progress_cb(ratio, f"HTML 생성 중... ({idx}/{total_segments})")
+        
+        if segment.translatable:
+            # 번역 가능한 세그먼트
+            html_parts.append(_render_translatable_segment(segment, translation_map, idx, is_markdown))
+        else:
+            # 번역 불가 세그먼트 (코드)
+            html_parts.append(_render_code_segment(segment, idx))
+    
+    html_parts.append(TEXT_HTML_FOOTER)
+    
+    if progress_cb:
+        progress_cb(1.0, "HTML 생성 완료")
+    
+    return "".join(html_parts)
+
+
+def _render_translatable_segment(
+    segment: TextSegment,
+    translation_map: dict,
+    idx: int,
+    is_markdown: bool = False
+) -> str:
+    """
+    번역 가능한 세그먼트를 HTML로 렌더링합니다.
+    
+    원문과 번역문을 모두 표시하며, 검수 모드에서 좌우 대조가 가능합니다.
+    is_markdown=True면 마크다운을 HTML로 렌더링합니다.
+    """
+    original = segment.text
+    translated = translation_map.get(original, original)
+    
+    # 세그먼트 타입에 따른 클래스 추가
+    extra_class = ""
+    if segment.segment_type == "comment":
+        extra_class = " comment-segment"
+    elif segment.segment_type == "docstring":
+        extra_class = " docstring-segment"
+    
+    if is_markdown:
+        # 마크다운을 HTML로 렌더링
+        md_converter.reset()
+        rendered_orig = md_converter.convert(original)
+        md_converter.reset()
+        rendered_trans = md_converter.convert(translated)
+        
+        # 원문은 data 속성에 좁은 형태로 저장 (툴팁용)
+        safe_orig_attr = html.escape(original[:200] + ('...' if len(original) > 200 else ''))
+        
+        return f"""
+    <div class="segment-row{extra_class}">
+        <div class="src-block md-content">
+            <div class="sent" id="src-{idx}-0">{rendered_orig}</div>
+        </div>
+        <div class="tgt-block md-content">
+            <div class="sent" id="tgt-{idx}-0" data-src="src-{idx}-0" data-src-text="{safe_orig_attr}">{rendered_trans}</div>
+        </div>
+    </div>
+    """
+    else:
+        # 일반 텍스트 (이스케이프 처리)
+        safe_orig = html.escape(original)
+        safe_trans = html.escape(translated)
+        
+        return f"""
+    <div class="segment-row{extra_class}">
+        <div class="src-block">
+            <span class="sent" id="src-{idx}-0">{safe_orig}</span>
+        </div>
+        <div class="tgt-block">
+            <span class="sent" id="tgt-{idx}-0" data-src="src-{idx}-0" data-src-text="{safe_orig}">{safe_trans}</span>
+        </div>
+    </div>
+    """
+
+
+def _render_code_segment(segment: TextSegment, idx: int) -> str:
+    """
+    번역 불가 세그먼트(코드)를 HTML로 렌더링합니다.
+    
+    코드 블록 스타일로 표시하며, 원문만 표시합니다.
+    """
+    safe_code = html.escape(segment.text)
+    
+    # 세그먼트 타입에 따른 라벨
+    type_labels = {
+        "code": "CODE",
+        "code_block": "CODE BLOCK",
+        "inline_code": "INLINE",
+    }
+    label = type_labels.get(segment.segment_type, "CODE")
+    
+    return f"""
+    <div class="code-segment-wrapper">
+        <div class="code-segment">
+            <span class="code-label">{label}</span>
+            <pre><code>{safe_code}</code></pre>
+        </div>
+    </div>
+    """
+
+
+def get_file_type_display(ext: str) -> str:
+    """
+    확장자에 따른 파일 타입 표시 문자열을 반환합니다.
+    
+    Args:
+        ext: 파일 확장자 (점 제외)
+        
+    Returns:
+        표시용 파일 타입 문자열
+    """
+    type_map = {
+        # 마크다운
+        "md": "Markdown",
+        "markdown": "Markdown",
+        "rst": "reStructuredText",
+        
+        # 프로그래밍 언어
+        "py": "Python",
+        "pyw": "Python",
+        "js": "JavaScript",
+        "jsx": "JavaScript (React)",
+        "ts": "TypeScript",
+        "tsx": "TypeScript (React)",
+        "c": "C",
+        "h": "C Header",
+        "cpp": "C++",
+        "hpp": "C++ Header",
+        "cc": "C++",
+        "cxx": "C++",
+        "cs": "C#",
+        "java": "Java",
+        "kt": "Kotlin",
+        "kts": "Kotlin Script",
+        "go": "Go",
+        "rs": "Rust",
+        "swift": "Swift",
+        
+        # 쉘
+        "sh": "Shell Script",
+        "bash": "Bash Script",
+        "zsh": "Zsh Script",
+        
+        # 설정
+        "json": "JSON",
+        "yaml": "YAML",
+        "yml": "YAML",
+        "toml": "TOML",
+        "xml": "XML",
+        
+        # 일반
+        "txt": "Plain Text",
+        "text": "Plain Text",
+        "log": "Log File",
+    }
+    
+    # 확장자가 없는 경우
+    if not ext:
+        return "Plain Text"
+    
+    return type_map.get(ext.lower(), "Text File")
+
+
+def generate_code_file_html(
+    file_name: str,
+    original_content: str,
+    segments: List[TextSegment],
+    translation_map: dict,
+    file_type: str = "Code",
+    progress_cb: Optional[ProgressCallback] = None
+) -> str:
+    """
+    코드 파일을 원본 구조 그대로 유지하면서 주석/독스트링만 번역하여 HTML 생성.
+    
+    주석과 독스트링은 번역문으로 대체되고, hover 시 원문을 볼 수 있습니다.
+    코드 부분은 그대로 유지되어 문맥을 잃지 않습니다.
+    
+    Args:
+        file_name: 파일명
+        original_content: 원본 파일 전체 내용
+        segments: 파싱된 세그먼트 리스트
+        translation_map: 원문 -> 번역문 매핑
+        file_type: 파일 타입 표시
+        progress_cb: 진행률 콜백
+    """
+    # 코드 파일용 HTML 헤더 (구문 강조 스타일 포함)
+    code_html_header = '''
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Code Translation - ''' + html.escape(file_name) + '''</title>
+    <style>
+        :root {
+            --bg-color: #1e1e1e;
+            --card-bg: #252526;
+            --text-color: #d4d4d4;
+            --sub-text-color: #808080;
+            --border-color: #3c3c3c;
+            --line-num-color: #858585;
+            --comment-color: #6a9955;
+            --string-color: #ce9178;
+            --keyword-color: #569cd6;
+            --function-color: #dcdcaa;
+            --highlight-bg: rgba(255, 255, 0, 0.2);
+        }
+        [data-theme="light"] {
+            --bg-color: #ffffff;
+            --card-bg: #f8f8f8;
+            --text-color: #333333;
+            --sub-text-color: #666666;
+            --border-color: #e0e0e0;
+            --line-num-color: #999999;
+            --comment-color: #008000;
+            --string-color: #a31515;
+            --keyword-color: #0000ff;
+            --function-color: #795e26;
+            --highlight-bg: rgba(255, 255, 0, 0.3);
+        }
+        
+        * { box-sizing: border-box; }
+        body { 
+            font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+            background: var(--bg-color); 
+            color: var(--text-color); 
+            margin: 0; 
+            padding: 20px;
+            line-height: 1.5;
+        }
+        
+        .controls {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 20px;
+            padding: 15px 20px;
+            background: var(--card-bg);
+            border-radius: 8px;
+            border: 1px solid var(--border-color);
+        }
+        
+        .file-info {
+            font-size: 0.9em;
+            color: var(--sub-text-color);
+        }
+        .file-info .filename {
+            font-weight: bold;
+            color: var(--text-color);
+            margin-right: 15px;
+        }
+        
+        .btn-group { display: flex; gap: 10px; }
+        .btn {
+            padding: 8px 16px;
+            background: transparent;
+            color: var(--text-color);
+            border: 1px solid var(--border-color);
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.85em;
+            transition: all 0.2s;
+        }
+        .btn:hover { background: var(--border-color); }
+        .btn.active { background: #007acc; border-color: #007acc; color: white; }
+        
+        .code-container {
+            background: var(--card-bg);
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            overflow: hidden;
+        }
+        
+        .code-view {
+            display: flex;
+            overflow-x: auto;
+        }
+        
+        .line-numbers {
+            padding: 20px 15px;
+            text-align: right;
+            color: var(--line-num-color);
+            background: var(--bg-color);
+            border-right: 1px solid var(--border-color);
+            user-select: none;
+            font-size: 0.85em;
+        }
+        
+        .code-content {
+            padding: 20px;
+            flex: 1;
+            overflow-x: auto;
+            white-space: pre;
+        }
+        
+        .code-line {
+            min-height: 1.5em;
+        }
+        
+        /* 번역된 주석 스타일 */
+        .translated-comment {
+            color: var(--comment-color);
+            cursor: pointer;
+            position: relative;
+            background: rgba(106, 153, 85, 0.1);
+            padding: 2px 4px;
+            border-radius: 3px;
+            transition: background 0.2s;
+        }
+        .translated-comment:hover {
+            background: rgba(106, 153, 85, 0.3);
+        }
+        
+        /* 툴팁 */
+        .translated-comment .tooltip {
+            display: none;
+            position: absolute;
+            bottom: 100%;
+            left: 0;
+            background: #333;
+            color: #fff;
+            padding: 10px 15px;
+            border-radius: 6px;
+            font-size: 0.9em;
+            white-space: pre-wrap;
+            max-width: 600px;
+            min-width: 200px;
+            z-index: 1000;
+            box-shadow: 0 4px 15px rgba(0,0,0,0.3);
+            margin-bottom: 8px;
+        }
+        .translated-comment:hover .tooltip {
+            display: block;
+        }
+        .tooltip-label {
+            font-size: 0.75em;
+            color: #aaa;
+            margin-bottom: 5px;
+            display: block;
+        }
+        
+        /* 원문 보기 모드 */
+        .show-original .translated-comment .trans-text { display: none; }
+        .show-original .translated-comment .orig-text { display: inline; }
+        .translated-comment .orig-text { display: none; }
+        
+        /* 기타 구문 */
+        .code-keyword { color: var(--keyword-color); }
+        .code-string { color: var(--string-color); }
+        .code-function { color: var(--function-color); }
+    </style>
+</head>
+<body>
+    <div class="controls">
+        <div class="file-info">
+            <span class="filename">📄 ''' + html.escape(file_name) + '''</span>
+            <span>''' + html.escape(file_type) + '''</span>
+        </div>
+        <div class="btn-group">
+            <button class="btn" onclick="toggleTheme()">🌓 테마</button>
+            <button class="btn" id="btn-mode" onclick="toggleMode()">📝 원문 보기</button>
+        </div>
+    </div>
+    <div class="code-container">
+        <div class="code-view" id="code-view">
+'''
+    
+    code_html_footer = '''
+        </div>
+    </div>
+    <script>
+        function toggleTheme() {
+            const body = document.body;
+            const current = body.getAttribute('data-theme');
+            body.setAttribute('data-theme', current === 'light' ? 'dark' : 'light');
+        }
+        function toggleMode() {
+            const view = document.getElementById('code-view');
+            const btn = document.getElementById('btn-mode');
+            if (view.classList.contains('show-original')) {
+                view.classList.remove('show-original');
+                btn.textContent = '📝 원문 보기';
+            } else {
+                view.classList.add('show-original');
+                btn.textContent = '🌐 번역 보기';
+            }
+        }
+    </script>
+</body>
+</html>
+'''
+    
+    # 원본 코드에서 주석을 직접 찾아서 대체
+    # 위치 기반 대체 대신 텍스트 기반 대체 사용 (더 안정적)
+    new_content = html.escape(original_content)
+    
+    # 번역 맵을 길이순으로 정렬 (긴 것 먼저 대체해서 부분 매칭 방지)
+    sorted_translations = sorted(
+        [(orig, trans) for orig, trans in translation_map.items() if orig != trans],
+        key=lambda x: len(x[0]),
+        reverse=True
+    )
+    
+    for original_text, translated_text in sorted_translations:
+        if original_text.strip():
+            # HTML 이스케이프된 원본 텍스트 찾기
+            escaped_orig = html.escape(original_text)
+            
+            if escaped_orig in new_content:
+                # 툴팁용 원문
+                safe_orig_tooltip = escaped_orig.replace('\n', '&#10;')
+                safe_trans = html.escape(translated_text)
+                
+                replacement = f'<span class="translated-comment"><span class="trans-text">{safe_trans}</span><span class="orig-text">{escaped_orig}</span><span class="tooltip"><span class="tooltip-label">원문:</span>{safe_orig_tooltip}</span></span>'
+                
+                # 첫 번째 매치만 대체 (같은 주석이 여러 번 나올 수 있으므로)
+                new_content = new_content.replace(escaped_orig, replacement, 1)
+    
+    # 줄 번호와 함께 HTML 생성
+    lines = new_content.split('\n')
+    line_nums_html = '<div class="line-numbers">'
+    code_html = '<div class="code-content">'
+    
+    for i, line in enumerate(lines, 1):
+        line_nums_html += f'{i}<br>'
+        # 빈 줄 처리
+        if not line.strip() and '<span' not in line:
+            code_html += '<div class="code-line">&nbsp;</div>'
+        else:
+            code_html += f'<div class="code-line">{line}</div>'
+    
+    line_nums_html += '</div>'
+    code_html += '</div>'
+    
+    if progress_cb:
+        progress_cb(1.0, "HTML 생성 완료")
+    
+    return code_html_header + line_nums_html + code_html + code_html_footer
+

--- a/src/text_parser.py
+++ b/src/text_parser.py
@@ -1,0 +1,550 @@
+"""
+src/text_parser.py
+==================
+텍스트 파일을 파싱하여 번역 대상 영역을 지능적으로 추출하는 모듈입니다.
+
+이 모듈은 다음 기능을 수행합니다:
+1.  **파일 타입 감지**: 확장자를 기반으로 파일 타입을 식별합니다.
+2.  **세그먼트 추출**: 파일을 번역 가능/불가능 영역으로 분리합니다.
+3.  **스마트 파싱**: 마크다운은 코드블록 제외, 코드 파일은 주석만 추출 등
+
+지원 파일 타입:
+- 마크다운: .md, .markdown, .rst
+- 파이썬: .py (# 주석, triple-quote 독스트링)
+- C 계열: .c, .cpp, .h, .java, .cs, .go, .rs, .swift (// 및 /* */ 주석)
+- 자바스크립트: .js, .ts, .jsx, .tsx
+- 쉘: .sh, .bash (# 주석)
+- 설정: .json, .yaml, .yml, .toml (전체 번역)
+- 일반 텍스트: .txt, LICENSE 등 (전체 번역)
+"""
+
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+from pathlib import Path
+import logging
+
+
+@dataclass
+class TextSegment:
+    """
+    번역 가능한 텍스트 조각을 나타내는 데이터 클래스입니다.
+    
+    Attributes:
+        text: 원본 텍스트
+        start_pos: 파일 내 시작 위치 (문자 인덱스)
+        end_pos: 파일 내 끝 위치 (문자 인덱스)
+        translatable: 번역 대상 여부
+        segment_type: 세그먼트 유형 ('prose', 'comment', 'code', 'docstring', 'header' 등)
+        line_number: 시작 줄 번호 (디버깅용)
+    """
+    text: str
+    start_pos: int
+    end_pos: int
+    translatable: bool
+    segment_type: str
+    line_number: int = 0
+
+
+class TextFileParser:
+    """
+    텍스트 파일을 파싱하여 번역 대상 영역을 추출합니다.
+    
+    파일 타입별로 다른 파싱 전략을 사용합니다:
+    - 마크다운: 코드블록/인라인코드 제외
+    - 코드 파일: 주석과 독스트링만 추출
+    - 일반 텍스트: 전체 번역
+    """
+    
+    # 파일 확장자 -> 파서 타입 매핑
+    EXTENSION_MAP = {
+        # 마크다운/문서
+        'md': 'markdown',
+        'markdown': 'markdown',
+        'rst': 'plaintext',  # RST는 일단 전체 번역
+        
+        # 파이썬
+        'py': 'python',
+        'pyw': 'python',
+        
+        # C 스타일 주석 (// 및 /* */)
+        'js': 'c_style',
+        'jsx': 'c_style',
+        'ts': 'c_style',
+        'tsx': 'c_style',
+        'mjs': 'c_style',
+        'cjs': 'c_style',
+        'c': 'c_style',
+        'h': 'c_style',
+        'cpp': 'c_style',
+        'hpp': 'c_style',
+        'cc': 'c_style',
+        'cxx': 'c_style',
+        'cs': 'c_style',
+        'java': 'c_style',
+        'kt': 'c_style',
+        'kts': 'c_style',
+        'go': 'c_style',
+        'rs': 'c_style',
+        'swift': 'c_style',
+        
+        # 쉘 스크립트 (# 주석)
+        'sh': 'shell',
+        'bash': 'shell',
+        'zsh': 'shell',
+        'fish': 'shell',
+        
+        # 설정 파일 (전체 번역)
+        'json': 'config',
+        'yaml': 'config',
+        'yml': 'config',
+        'toml': 'config',
+        'xml': 'config',
+        
+        # 일반 텍스트
+        'txt': 'plaintext',
+        'text': 'plaintext',
+        'log': 'plaintext',
+        'cfg': 'plaintext',
+        'ini': 'plaintext',
+        'env': 'plaintext',
+    }
+    
+    def __init__(self):
+        """파서 초기화"""
+        pass
+    
+    def parse(self, file_path: Path) -> List[TextSegment]:
+        """
+        파일을 파싱하여 세그먼트 리스트를 반환합니다.
+        
+        Args:
+            file_path: 파싱할 파일 경로
+            
+        Returns:
+            TextSegment 리스트
+        """
+        file_path = Path(file_path)
+        ext = file_path.suffix.lstrip('.').lower()
+        
+        # 파서 타입 결정
+        parser_type = self.EXTENSION_MAP.get(ext, 'plaintext')
+        
+        # 확장자가 없는 경우 (LICENSE, README 등)
+        if not ext:
+            parser_type = 'plaintext'
+        
+        # 파일 읽기 (인코딩 오류는 무시)
+        try:
+            content = file_path.read_text(encoding='utf-8')
+        except UnicodeDecodeError:
+            try:
+                content = file_path.read_text(encoding='cp949')
+            except UnicodeDecodeError:
+                content = file_path.read_text(encoding='utf-8', errors='ignore')
+        
+        logging.info(f"[TextParser] 파일 파싱: {file_path.name} (타입: {parser_type})")
+        
+        # 파서 타입에 따라 분기
+        if parser_type == 'markdown':
+            return self._parse_markdown(content)
+        elif parser_type == 'python':
+            return self._parse_python(content)
+        elif parser_type == 'c_style':
+            return self._parse_c_style(content)
+        elif parser_type == 'shell':
+            return self._parse_shell(content)
+        elif parser_type == 'config':
+            return self._parse_config(content)
+        else:
+            return self._parse_plaintext(content)
+    
+    def _parse_markdown(self, content: str) -> List[TextSegment]:
+        """
+        마크다운 파싱: 코드블록만 분리, 인라인 코드는 포함된 채로 번역
+        
+        번역 제외 대상:
+        - 코드 블록: ```...``` 또는 ~~~...~~~
+        
+        인라인 코드(`...`)는 텍스트에 포함된 채로 번역 (HTML 렌더링 시 스타일링만)
+        """
+        segments = []
+        pos = 0
+        line_number = 1
+        
+        # 코드 블록 패턴: ```language\n...\n``` 또는 ~~~...~~~
+        code_block_pattern = re.compile(r'(```[\w]*\n.*?\n```|~~~[\w]*\n.*?\n~~~)', re.DOTALL)
+        
+        # 코드 블록 찾기
+        for match in code_block_pattern.finditer(content):
+            # 코드 블록 이전 텍스트 (번역 대상) - 문단 단위로 분리
+            if match.start() > pos:
+                before_text = content[pos:match.start()]
+                if before_text.strip():
+                    # 문단 단위로 분리 (빈 줄 기준)
+                    para_segments = self._split_by_paragraphs(before_text, pos, line_number)
+                    segments.extend(para_segments)
+                line_number += before_text.count('\n')
+            
+            # 코드 블록 (번역 불가)
+            code_text = match.group()
+            segments.append(TextSegment(
+                text=code_text,
+                start_pos=match.start(),
+                end_pos=match.end(),
+                translatable=False,
+                segment_type='code_block',
+                line_number=line_number
+            ))
+            line_number += code_text.count('\n')
+            pos = match.end()
+        
+        # 마지막 텍스트
+        if pos < len(content):
+            remaining = content[pos:]
+            if remaining.strip():
+                para_segments = self._split_by_paragraphs(remaining, pos, line_number)
+                segments.extend(para_segments)
+        
+        return segments
+    
+    def _split_by_paragraphs(self, text: str, start_pos: int, line_number: int) -> List[TextSegment]:
+        """
+        텍스트를 문단 단위로 분리하여 세그먼트 리스트 반환
+        빈 줄(\n\n)을 기준으로 문단 분리
+        """
+        segments = []
+        paragraphs = re.split(r'\n\s*\n', text)
+        current_pos = start_pos
+        current_line = line_number
+        
+        for para in paragraphs:
+            if para.strip():
+                segments.append(TextSegment(
+                    text=para.strip(),
+                    start_pos=current_pos,
+                    end_pos=current_pos + len(para),
+                    translatable=True,
+                    segment_type='prose',
+                    line_number=current_line
+                ))
+            current_line += para.count('\n') + 2  # 문단 구분자 포함
+            current_pos += len(para) + 2
+        
+        return segments
+    
+    def _parse_python(self, content: str) -> List[TextSegment]:
+        """
+        파이썬 파싱: 주석(#)과 독스트링(triple quotes)만 번역
+        
+        번역 대상:
+        - 한 줄 주석: # comment
+        - 독스트링: triple single/double quotes (줄 단위 분리)
+        """
+        segments = []
+        pos = 0
+        line_number = 1
+        
+        # 패턴: 독스트링 또는 한 줄 주석
+        pattern = re.compile(
+            r'("""|\'\'\')([\s\S]*?)(\1)|#[^\n]*',
+            re.MULTILINE
+        )
+        
+        for match in pattern.finditer(content):
+            # 매치 이전 코드 (번역 불가)
+            if match.start() > pos:
+                code_text = content[pos:match.start()]
+                if code_text.strip():
+                    segments.append(TextSegment(
+                        text=code_text,
+                        start_pos=pos,
+                        end_pos=match.start(),
+                        translatable=False,
+                        segment_type='code',
+                        line_number=line_number
+                    ))
+                line_number += code_text.count('\n')
+            
+            # 주석 또는 독스트링 (번역 대상)
+            comment_text = match.group()
+            is_docstring = comment_text.startswith('"""') or comment_text.startswith("'''")
+            
+            if is_docstring:
+                # 독스트링은 줄 단위로 분리하여 가독성 향상
+                lines = comment_text.split('\n')
+                for i, line in enumerate(lines):
+                    if line.strip():
+                        segments.append(TextSegment(
+                            text=line,
+                            start_pos=match.start(),
+                            end_pos=match.end(),
+                            translatable=True,
+                            segment_type='docstring',
+                            line_number=line_number + i
+                        ))
+            else:
+                # 한 줄 주석
+                segments.append(TextSegment(
+                    text=comment_text,
+                    start_pos=match.start(),
+                    end_pos=match.end(),
+                    translatable=True,
+                    segment_type='comment',
+                    line_number=line_number
+                ))
+            
+            line_number += comment_text.count('\n')
+            pos = match.end()
+        
+        # 마지막 코드
+        if pos < len(content):
+            remaining = content[pos:]
+            if remaining.strip():
+                segments.append(TextSegment(
+                    text=remaining,
+                    start_pos=pos,
+                    end_pos=len(content),
+                    translatable=False,
+                    segment_type='code',
+                    line_number=line_number
+                ))
+        
+        return segments
+    
+    def _parse_c_style(self, content: str) -> List[TextSegment]:
+        """
+        C 스타일 주석 파싱: //, /* */ 주석만 번역
+        
+        지원 언어: C, C++, Java, C#, JavaScript, TypeScript, Go, Rust, Swift
+        
+        번역 대상:
+        - 한 줄 주석: // comment
+        - 여러 줄 주석: /* ... */
+        - Rust 문서 주석: /// ...
+        """
+        segments = []
+        pos = 0
+        line_number = 1
+        
+        # 패턴: // 주석, /* */ 여러줄 주석
+        pattern = re.compile(
+            r'(//[^\n]*|/\*[\s\S]*?\*/)',
+            re.MULTILINE
+        )
+        
+        for match in pattern.finditer(content):
+            # 매치 이전 코드
+            if match.start() > pos:
+                code_text = content[pos:match.start()]
+                if code_text.strip():
+                    segments.append(TextSegment(
+                        text=code_text,
+                        start_pos=pos,
+                        end_pos=match.start(),
+                        translatable=False,
+                        segment_type='code',
+                        line_number=line_number
+                    ))
+                line_number += code_text.count('\n')
+            
+            # 주석 (번역 대상)
+            comment_text = match.group()
+            segment_type = 'block_comment' if comment_text.startswith('/*') else 'line_comment'
+            
+            segments.append(TextSegment(
+                text=comment_text,
+                start_pos=match.start(),
+                end_pos=match.end(),
+                translatable=True,
+                segment_type=segment_type,
+                line_number=line_number
+            ))
+            line_number += comment_text.count('\n')
+            pos = match.end()
+        
+        # 마지막 코드
+        if pos < len(content):
+            remaining = content[pos:]
+            if remaining.strip():
+                segments.append(TextSegment(
+                    text=remaining,
+                    start_pos=pos,
+                    end_pos=len(content),
+                    translatable=False,
+                    segment_type='code',
+                    line_number=line_number
+                ))
+        
+        return segments
+    
+    def _parse_shell(self, content: str) -> List[TextSegment]:
+        """
+        쉘 스크립트 파싱: # 주석만 번역 (shebang 제외)
+        
+        번역 대상:
+        - 주석: # comment (단, #!로 시작하는 shebang 제외)
+        """
+        segments = []
+        pos = 0
+        line_number = 1
+        
+        # 패턴: # 주석 (shebang 제외)
+        # shebang: #!/bin/bash 등은 제외
+        pattern = re.compile(r'^(?!#!)#[^\n]*', re.MULTILINE)
+        
+        for match in pattern.finditer(content):
+            # 매치 이전 코드
+            if match.start() > pos:
+                code_text = content[pos:match.start()]
+                if code_text.strip():
+                    segments.append(TextSegment(
+                        text=code_text,
+                        start_pos=pos,
+                        end_pos=match.start(),
+                        translatable=False,
+                        segment_type='code',
+                        line_number=line_number
+                    ))
+                line_number += code_text.count('\n')
+            
+            # 주석 (번역 대상)
+            comment_text = match.group()
+            segments.append(TextSegment(
+                text=comment_text,
+                start_pos=match.start(),
+                end_pos=match.end(),
+                translatable=True,
+                segment_type='comment',
+                line_number=line_number
+            ))
+            pos = match.end()
+        
+        # 마지막 코드
+        if pos < len(content):
+            remaining = content[pos:]
+            if remaining.strip():
+                segments.append(TextSegment(
+                    text=remaining,
+                    start_pos=pos,
+                    end_pos=len(content),
+                    translatable=False,
+                    segment_type='code',
+                    line_number=line_number
+                ))
+        
+        return segments
+    
+    def _parse_config(self, content: str) -> List[TextSegment]:
+        """
+        설정 파일 파싱: 전체 번역 (키와 값 모두)
+        
+        지원 형식: JSON, YAML, TOML, XML
+        
+        주의: 번역 후 파일 구조가 깨질 수 있으므로 사용자에게 경고 필요
+        """
+        # 전체를 하나의 번역 가능 세그먼트로 처리
+        return [TextSegment(
+            text=content,
+            start_pos=0,
+            end_pos=len(content),
+            translatable=True,
+            segment_type='config',
+            line_number=1
+        )]
+    
+    def _parse_plaintext(self, content: str) -> List[TextSegment]:
+        """
+        일반 텍스트 파싱: 전체 번역
+        
+        적용 대상: .txt, LICENSE, README (확장자 없음) 등
+        """
+        # 문단 단위로 분리하여 번역 효율성 향상
+        segments = []
+        paragraphs = content.split('\n\n')
+        pos = 0
+        line_number = 1
+        
+        for para in paragraphs:
+            if para.strip():
+                segments.append(TextSegment(
+                    text=para,
+                    start_pos=pos,
+                    end_pos=pos + len(para),
+                    translatable=True,
+                    segment_type='prose',
+                    line_number=line_number
+                ))
+            line_number += para.count('\n') + 2  # 문단 구분자 포함
+            pos += len(para) + 2  # \n\n
+        
+        # 빈 문단은 추가하지 않으므로, 전체가 비어있으면 하나로 처리
+        if not segments and content.strip():
+            segments.append(TextSegment(
+                text=content,
+                start_pos=0,
+                end_pos=len(content),
+                translatable=True,
+                segment_type='prose',
+                line_number=1
+            ))
+        
+        return segments
+    
+    def get_translatable_texts(self, segments: List[TextSegment]) -> List[str]:
+        """
+        세그먼트 리스트에서 번역 대상 텍스트만 추출합니다.
+        
+        Args:
+            segments: TextSegment 리스트
+            
+        Returns:
+            번역 대상 텍스트 리스트
+        """
+        return [seg.text for seg in segments if seg.translatable and seg.text.strip()]
+
+
+def is_text_file(file_path: str) -> bool:
+    """
+    파일이 텍스트 파일인지 확인합니다.
+    
+    확장자 기반으로 판단하며, 확장자가 없는 경우 바이너리 체크를 수행합니다.
+    
+    Args:
+        file_path: 확인할 파일 경로
+        
+    Returns:
+        텍스트 파일이면 True
+    """
+    path = Path(file_path)
+    ext = path.suffix.lstrip('.').lower()
+    
+    # 알려진 텍스트 확장자
+    if ext in TextFileParser.EXTENSION_MAP:
+        return True
+    
+    # 확장자 없는 파일 (LICENSE, README 등)
+    if not ext:
+        return not _is_binary(file_path)
+    
+    return False
+
+
+def _is_binary(file_path: str) -> bool:
+    """
+    파일이 바이너리인지 확인합니다.
+    
+    파일의 처음 8KB를 읽어 null byte가 있으면 바이너리로 판단합니다.
+    
+    Args:
+        file_path: 확인할 파일 경로
+        
+    Returns:
+        바이너리 파일이면 True
+    """
+    try:
+        with open(file_path, 'rb') as f:
+            chunk = f.read(8192)
+            return b'\x00' in chunk
+    except Exception:
+        return True  # 읽기 실패 시 바이너리로 취급


### PR DESCRIPTION
- Add TextFileParser for smart parsing of text-based files
- Add TextHTMLGenerator for interactive HTML output
- Support Markdown files with proper HTML rendering
- Support code files (.py, .js, .ts, etc.) with comment-only translation
- Support plain text files with paragraph-based segmentation
- Add code viewer with line numbers, theme toggle, and original/translated toggle
- Update README.md and docs/README.en.md with new features
- Update main.py help text and docstring
- Add markdown>=3.5.0 to requirements.txt

Closes #97